### PR TITLE
FileSavedSuccessfully, OpenContainingFolder, VideoGenerationFailed

### DIFF
--- a/TeroSubtitler/bin/Languages/it-IT.xml
+++ b/TeroSubtitler/bin/Languages/it-IT.xml
@@ -162,7 +162,7 @@
       <actExportCustomTextFormat>Formato di testo personalizzato…</actExportCustomTextFormat>
       <actExportCustomImageFormat>Formato di immagine personalizzata…</actExportCustomImageFormat>
       <actExportSUP>Formato .sup per Blu-ray…</actExportSUP>
-      <actGenerateVideo>Genera video con sottotitoli fissi…</actGenerateVideo>
+      <actGenerateVideo>Genera video con sottotitoli impressi…</actGenerateVideo>
       <actMediaPreviousFrame>Fotogramma precedente</actMediaPreviousFrame>
       <actMediaNextFrame>Fotogramma successivo</actMediaNextFrame>
       <actMediaMoveSubtitle>Sposta sottotitolo</actMediaMoveSubtitle>
@@ -795,6 +795,9 @@
     <ShortCutInUse>Scorciatoia attualmente in uso per ‘%s’.</ShortCutInUse>
     <AdditionalParams>Parametri aggiuntivi:</AdditionalParams>
     <Line>Riga:</Line>
+    <FileSavedSuccessfully>File salvato con successo.</FileSavedSuccessfully>
+    <VideoGenerationFailed>Errore nella creazione del video.</VideoGenerationFailed>
+    <OpenContainingFolder>Apri la cartella di destinazione</OpenContainingFolder>
   </CommonStrings>
   <CommonControls>
     <rbnAllTheSubtitles>Tutti i sottotitoli</rbnAllTheSubtitles>

--- a/TeroSubtitler/bin/tero.app/Contents/Resources/Languages/it-IT.xml
+++ b/TeroSubtitler/bin/tero.app/Contents/Resources/Languages/it-IT.xml
@@ -162,7 +162,7 @@
       <actExportCustomTextFormat>Formato di testo personalizzato…</actExportCustomTextFormat>
       <actExportCustomImageFormat>Formato di immagine personalizzata…</actExportCustomImageFormat>
       <actExportSUP>Formato .sup per Blu-ray…</actExportSUP>
-      <actGenerateVideo>Genera video con sottotitoli fissi…</actGenerateVideo>
+      <actGenerateVideo>Genera video con sottotitoli impressi…</actGenerateVideo>
       <actMediaPreviousFrame>Fotogramma precedente</actMediaPreviousFrame>
       <actMediaNextFrame>Fotogramma successivo</actMediaNextFrame>
       <actMediaMoveSubtitle>Sposta sottotitolo</actMediaMoveSubtitle>
@@ -795,6 +795,9 @@
     <ShortCutInUse>Scorciatoia attualmente in uso per ‘%s’.</ShortCutInUse>
     <AdditionalParams>Parametri aggiuntivi:</AdditionalParams>
     <Line>Riga:</Line>
+    <FileSavedSuccessfully>File salvato con successo.</FileSavedSuccessfully>
+    <VideoGenerationFailed>Errore nella creazione del video.</VideoGenerationFailed>
+    <OpenContainingFolder>Apri la cartella di destinazione</OpenContainingFolder>
   </CommonStrings>
   <CommonControls>
     <rbnAllTheSubtitles>Tutti i sottotitoli</rbnAllTheSubtitles>


### PR DESCRIPTION
• Updated to commit [`665e86f`](https://github.com/URUWorks/TeroSubtitler/commit/665e86f9146070fc514341ef670390d31a333f25) and [`d647f6e`](https://github.com/URUWorks/TeroSubtitler/commit/d647f6ed4e5452bbc5b1abe56c2d077ec4c60b74)
• Improved Italian translation of «hardcoded subtitles»