### PR TITLE
Fix: Linux Mint Cinnamon: Wrong behaviour of time controls #359

### DIFF
--- a/TeroSubtitler/controls/UWTimeEdit.pas
+++ b/TeroSubtitler/controls/UWTimeEdit.pas
@@ -71,7 +71,7 @@ type
     procedure AdjustClientRect(var ARect: TRect); override;
     {$ENDIF}
     procedure DoContextPopup(MousePos: TPoint; var Handled: Boolean); override;
-    procedure MouseDown(Button: TMouseButton; Shift: TShiftState; X, Y: Integer); override;
+    procedure MouseUp(Button: TMouseButton; Shift: TShiftState; X, Y: Integer); override;
     procedure KeyDown(var Key: Word; Shift: TShiftState); override;
     function DoMouseWheel(Shift: TShiftState; WheelDelta: Integer; MousePos: TPoint): Boolean; override;
     procedure CMVisibleChanged(var Msg: TLMessage); message CM_VISIBLECHANGED;
@@ -297,7 +297,7 @@ end;
 
 // -----------------------------------------------------------------------------
 
-procedure TUWTimeEdit.MouseDown(Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
+procedure TUWTimeEdit.MouseUp(Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
 begin
   // 01 34 67 901
   //   2  5  8

--- a/TeroSubtitler/src/procVST_Loops.pas
+++ b/TeroSubtitler/src/procVST_Loops.pas
@@ -22,7 +22,8 @@ unit procVST_Loops;
 interface
 
 uses
-  Classes, SysUtils, LCLIntf, UWSubtitleAPI, procTypes;
+  Classes, SysUtils, LCLIntf, LazUTF8,
+  UWSubtitleAPI, procTypes;
 
 procedure ApplyCheckErrors(const Item: PUWSubtitleItem; const Index: Integer);
 procedure ApplyCheckErrorsTimesOnly(const Item: PUWSubtitleItem; const Index: Integer);
@@ -141,7 +142,11 @@ begin
     if AnsiStartsText(sTag, Text) and AnsiEndsText(eTag, Text) then
       Result := Copy(Text, Length(sTag)+1, Length(Text) - (Length(sTag)+Length(eTag)))
     else
-      Result := sTag + Text + eTag;
+    begin
+      Result := UTF8StringReplace(Text,sTag,'',[rfReplaceAll,rfIgnoreCase]);
+      Result := UTF8StringReplace(Result,eTag,'',[rfReplaceAll,rfIgnoreCase]);
+      Result := sTag + Result + eTag;
+    end;
   end
   else
     Result := '';


### PR DESCRIPTION
Fix for Linux Mint Cinnamon: Wrong behaviour of time controls #359 (https://github.com/URUWorks/TeroSubtitler/issues/359)